### PR TITLE
adding missing SendNullByte()

### DIFF
--- a/transport_unix.go
+++ b/transport_unix.go
@@ -64,6 +64,11 @@ func init() {
 	transports["unix"] = newUnixTransport
 }
 
+func (t *unixTransport) SendNullByte() error {
+	t.hasUnixFDs = true
+	return nil
+}
+
 func (t *unixTransport) EnableUnixFDs() {
 	t.hasUnixFDs = true
 }


### PR DESCRIPTION
Hi,

i added the missing SendNullByte() function for unixTransport to be able to use dbus on FreeBSD.
Cheers,
tpltnt
